### PR TITLE
CR-0004_TextInlineAm

### DIFF
--- a/src/components/atoms/TextInlineAm.vue
+++ b/src/components/atoms/TextInlineAm.vue
@@ -1,0 +1,35 @@
+<template lang="pug">
+span(:class='modifyClassObject')
+  | {{ text }}
+</template>
+
+<script lang='ts' setup>
+import { computed } from 'vue'
+const props = defineProps({
+  text: { 
+    type: String, 
+    default: ''
+  },
+});
+
+const classCheck1 = true
+const classCheck2 = false
+
+const modifyClassObject = computed(() => {
+  return [
+    {'className1': classCheck1}, 
+    {'className2': classCheck2}, 
+  ]
+})
+</script>
+
+<style lang="sass" scoped>
+span 
+  margin: 0
+  padding: 0
+  color: inherit
+  font-size: inherit
+  font-weight: inherit
+  line-height: 1.3
+
+</style>

--- a/src/stories/atoms/TextInlineAm.story.vue
+++ b/src/stories/atoms/TextInlineAm.story.vue
@@ -1,0 +1,40 @@
+<template lang="pug">
+story(
+  title='TextInlineAm' 
+  :layout={
+    type: 'grid',
+    width: 300,
+  }
+)
+  variant(
+    title='text' 
+  )
+    span(:class='modifyClassObject')
+      | {{ text }}
+
+</template>
+
+<script lang='ts' setup>
+import TextInlineAm from '@/components/atoms/TextInlineAm.vue'
+
+const text = 'テキスト'
+const modifyClassObject = 'modifyClassObject'
+
+</script>
+
+<docs lang="md">
+  # TextInlineAm
+  
+  `<span>`についてのコンポーネントです。  
+  color, font-size, font-weight は親要素の値を引き継ぎます。  
+  class がどうしても必要な際は modifyClassObject を使用してください。  
+  [チケット](https://www.notion.so/HOME-a5cfd10d185b446187ab78551d8a3af2?p=9d920f9105a34c34a6f5a4c8fd04aa32&pm=s)
+  
+  ## Props
+  
+  | Name        | Type                         | Default   | Description                    |
+  | --------    | ---------------------------- | --------- | ------------------------------ |
+  | text        | String             | ''       |  |
+  |             |                    |          |  |
+
+  </docs>


### PR DESCRIPTION
  # TextInlineAm
  
  `<span>`についてのコンポーネントです。  
  color, font-size, font-weight は親要素の値を引き継ぎます。  
  class がどうしても必要な際は modifyClassObject を使用してください。  
  [チケット](https://www.notion.so/HOME-a5cfd10d185b446187ab78551d8a3af2?p=9d920f9105a34c34a6f5a4c8fd04aa32&pm=s)
  
  ## Props
  
  | Name        | Type                         | Default   | Description                    |
  | --------    | ---------------------------- | --------- | ------------------------------ |
  | text        | String             | ''       |  |
  |             |                    |          |  |
