### PR TITLE
 CR-0005_ButtonAm

### DIFF
--- a/src/assets/main.sass
+++ b/src/assets/main.sass
@@ -10,9 +10,19 @@ a, .green
   color: hsla(160, 100%, 37%, 1)
   transition: 0.4s
   padding: 3px
+*
+  color: var(--def-font-color)
+a, button
+  &:hover
+    opacity: .8 !important
+button, input, textarea
+  &:disabled
+    color: var(--de-emph-font-color) !important
+    background-color: var(--de-emph-background-color-box) !important
+    cursor: not-allowed !important
 @media (hover: hover)
-  a:hover
-    background-color: hsla(160, 100%, 37%, 0.2)
+  // a:hover
+  //   background-color: hsla(160, 100%, 37%, 0.2)
 @media (min-width: 1024px)
   // body
   //   display: flex

--- a/src/components/atoms/ButtonAm.vue
+++ b/src/components/atoms/ButtonAm.vue
@@ -1,0 +1,81 @@
+<template lang="pug">
+button(
+  :disabled='disabled'
+  :class='modifyClassObject'
+  @click='handleButtonEvent'
+)
+  template(v-if="hasText")
+    template(v-if="type === 'icon-prefix'")
+      span アイコン
+    TextInlineAm(
+      :text='text'
+    )
+    template(v-if="type === 'icon-suffix'")
+      span アイコン
+  template(v-if="type === 'icon-only'")
+    span アイコンだけ
+</template>
+
+<script lang='ts' setup>
+import { computed } from 'vue'
+import TextInlineAm from '@/components/atoms/TextInlineAm.vue'
+const props = defineProps({
+  type: {
+    type: String,
+    default: 'text-only',
+
+    validator: (value: string) => {
+      return ['text-only', 'icon-only', 'icon-prefix', 'icon-suffix'].includes(
+        value
+      )
+    }
+  },
+  text: { 
+    type: String, 
+    default: ''
+  },
+  disabled: { 
+    type: Boolean, 
+    default: false
+  },
+});
+
+const classCheck1 = true
+const classCheck2 = false
+
+const modifyClassObject = computed(() => {
+  return [
+    {'className1': classCheck1}, 
+    {'className2': classCheck2}, 
+  ]
+})
+
+const hasText = computed(() => {
+  return ([
+    'text-only', 
+    'icon-prefix', 
+    'icon-suffix'
+  ].includes(props.type))
+})
+
+const emit = defineEmits<{
+  (e: 'onClick'): void
+}>()
+
+const handleButtonEvent = () => {
+  emit('onClick')
+}
+</script>
+
+<style lang="sass" scoped>
+button 
+  background-color: var(--def-background-color-box)
+  border: 1px solid var(--def-border-color)
+  cursor: pointer
+  outline: none
+  padding: 8px 16px
+  border-radius: 16px
+  appearance: none
+  font-size: 1.4rem
+
+</style>

--- a/src/components/atoms/InputAm.vue
+++ b/src/components/atoms/InputAm.vue
@@ -57,7 +57,6 @@ input
   -webkit-appearance: none
   -moz-appearance: none
   appearance: none
-  color: var(--def-font-color)
   font-size: 1.6rem
   &[type="date"]::-webkit-inner-spin-button,
   &[type="date"]::-webkit-clear-button,
@@ -67,9 +66,5 @@ input
     color: var(--de-emph-font-color) 
   &:focus
     border-bottom: 2px solid var(--emph-border-color)
-  &:disabled
-    color: var(--de-emph-font-color)  
-    background-color: var(--de-emph-background-color-box)
-    cursor: not-allowed 
     
 </style>

--- a/src/components/atoms/TextareaAm.vue
+++ b/src/components/atoms/TextareaAm.vue
@@ -51,15 +51,10 @@ textarea
   -webkit-appearance: none
   -moz-appearance: none
   appearance: none
-  color: var(--def-font-color)
   font-size: 1.6rem
   &::placeholder
     color: var(--de-emph-font-color) 
   &:focus
     border-bottom: 2px solid var(--emph-border-color)
-  &:disabled
-    color: var(--de-emph-font-color)  
-    background-color: var(--de-emph-background-color-box)
-    cursor: not-allowed 
     
 </style>

--- a/src/stories/atoms/ButtonAm.story.vue
+++ b/src/stories/atoms/ButtonAm.story.vue
@@ -1,0 +1,71 @@
+<template lang="pug">
+story(
+  title='ButtonAm' 
+  :layout={
+    type: 'grid',
+    width: 200,
+  }
+)
+  variant(
+    title='button' 
+  )
+    ButtonAm(
+      type='text-only'
+      @click="logEvent('Click', $event)"
+
+      :text="text"
+    )
+  variant(
+    title='icon-button' 
+  )
+    ButtonAm(
+      type='icon-only'
+      :text="text"
+    )
+  variant(
+    title='icon-prefix-button' 
+  )
+    ButtonAm(
+      type='icon-prefix'
+      :text="text"
+    )
+  variant(
+    title='icon-suffix-button' 
+  )
+    ButtonAm(
+      type='icon-suffix'
+      :text="text"
+    )
+
+</template>
+
+<script lang='ts' setup>
+import ButtonAm from '@/components/atoms/ButtonAm.vue'
+import { logEvent } from 'histoire/client'
+
+const text = 'ボタン'
+</script>
+
+<docs lang="md">
+  # ButtonAm
+
+  ToDo アイコンを追加して差し替え
+  
+  `<button>`についてのコンポーネントです。  
+  [チケット](https://www.notion.so/HOME-a5cfd10d185b446187ab78551d8a3af2?p=52bb97218e1049e987554b08da1dcf1a&pm=s)
+  
+  ## Props
+  
+  | Name        | Type                         | Default   | Description                    |
+  | --------    | ---------------------------- | --------- | ------------------------------ |
+  | type        | 'text-only', 'icon-only', 'icon-prefix', 'icon-suffix' | 'text-only' |  |
+  | text        | String                       | ''        |  |
+  | disabled    | Boolean                      | false     |  |
+
+  ## Emits
+
+  | Name        | Event type     | Description                    |
+  | --------    | -------------- | ------------------------------ |
+  | onClick     | click          | クリックを検知します、 |
+ 
+  </docs>

--- a/src/stories/atoms/InputAm.story.vue
+++ b/src/stories/atoms/InputAm.story.vue
@@ -76,9 +76,9 @@ import { logEvent } from 'histoire/client'
   | Name        | Type                         | Default   | Description                    |
   | --------    | ---------------------------- | --------- | ------------------------------ |
   | type        | 'text', 'number', 'date', 'email', 'password', 'search', 'url' | 'text' |  |
-  | value       | String \|\| Number | null     |  |
-  | placeholder | String \|\| Number | null     |  |
-  | disabled    | boolean                      | false     |  |
+  | value       | String \|\| Number | null    |  |
+  | placeholder | String \|\| Number | null    |  |
+  | disabled    | Boolean                      | false     |  |
 
   ## Emits
 

--- a/src/stories/atoms/TextareaAm.story.vue
+++ b/src/stories/atoms/TextareaAm.story.vue
@@ -33,9 +33,9 @@ import { logEvent } from 'histoire/client'
   
   | Name        | Type                         | Default   | Description                    |
   | --------    | ---------------------------- | --------- | ------------------------------ |
-  | value       | String \|\| Number | null     |  |
-  | placeholder | String \|\| Number | null     |  |
-  | disabled    | boolean                      | false     |  |
+  | value       | String \|\| Number | null    |  |
+  | placeholder | String \|\| Number | null    |  |
+  | disabled    | Boolean                      | false     |  |
 
   ## Emits
 


### PR DESCRIPTION
  # ButtonAm

  ToDo アイコンを追加して差し替え
  
  `<button>`についてのコンポーネントです。  
  [チケット](https://www.notion.so/HOME-a5cfd10d185b446187ab78551d8a3af2?p=52bb97218e1049e987554b08da1dcf1a&pm=s)
  
  ## Props
  
  | Name        | Type                         | Default   | Description                    |
  | --------    | ---------------------------- | --------- | ------------------------------ |
  | type        | 'text-only', 'icon-only', 'icon-prefix', 'icon-suffix' | 'text-only' |  |
  | text        | String                       | ''        |  |
  | disabled    | Boolean                      | false     |  |

  ## Emits

  | Name        | Event type     | Description                    |
  | --------    | -------------- | ------------------------------ |
  | onClick     | click          | クリックを検知します、 |
 